### PR TITLE
Fix link to repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:balajmarius/vscode-jsdocs-deprecated.git"
+    "url": "https://github.com/vscode-jsdocs-deprecated"
   },
   "keywords": [
     "vscode",


### PR DESCRIPTION
Hi

Right now if you click on link to repository, 404 github page will be opened instead.